### PR TITLE
Allow forecast and timemachine to return headers

### DIFF
--- a/lib/darkskyx/api.ex
+++ b/lib/darkskyx/api.ex
@@ -15,6 +15,12 @@ defmodule Darkskyx.Api do
   def forecast(lat, lng, params \\ defaults()), do: read("#{lat},#{lng}", params)
 
   @doc """
+  Perform a forecast API call for given latitude longitude and also returns headers
+  """
+  def forecast_with_headers(lat, lng, params \\ defaults()),
+    do: read("#{lat},#{lng}", params, true)
+
+  @doc """
   Perform a time machine API call for given latitude, longitude and time
 
   ## time
@@ -27,6 +33,13 @@ defmodule Darkskyx.Api do
   def time_machine(lat, lng, time, params \\ defaults()),
     do: read("#{lat},#{lng},#{time}", params)
 
+  @doc """
+  Perform a time machine API call for given latitude, longitude and time and returns headers
+  """
+
+  def time_machine_with_headers(lat, lng, time, params \\ defaults()),
+    do: read("#{lat},#{lng},#{time}", params, true)
+
   def build_url(path_arg, query_params) do
     query_params =
       query_params
@@ -35,11 +48,11 @@ defmodule Darkskyx.Api do
     "#{@base_url}/#{api_key()}/#{path_arg}?#{URI.encode_query(query_params)}"
   end
 
-  def read(path_arg, query_params \\ %{}) do
+  def read(path_arg, query_params \\ %{}, with_headers \\ false) do
     path_arg
     |> build_url(query_params)
     |> Api.get(request_headers())
-    |> Parser.parse()
+    |> Parser.parse(with_headers)
   end
 
   def process_params(nil), do: defaults()

--- a/lib/darkskyx/parser.ex
+++ b/lib/darkskyx/parser.ex
@@ -10,12 +10,16 @@ defmodule Darkskyx.Parser do
   @doc """
   Parses the response from darksky API calls
   """
-  @spec parse(tuple) :: response
-  def parse(response) do
+  @spec parse(tuple, boolean) :: response
+  def parse(response, with_headers) do
     case response do
-      {:ok, %HTTPoison.Response{body: body, headers: _, status_code: status}}
+      {:ok, %HTTPoison.Response{body: body, headers: headers, status_code: status}}
       when status in [200, 201] ->
-        {:ok, parse_success_response(body)}
+        if with_headers do
+          {:ok, parse_success_response(body), parse_headers(headers)}
+        else
+          {:ok, parse_success_response(body)}
+        end
 
       {:ok, %HTTPoison.Response{body: _, headers: _, status_code: 204}} ->
         :ok
@@ -38,5 +42,10 @@ defmodule Darkskyx.Parser do
   defp parse_success_response(body) do
     body
     |> Poison.decode!()
+  end
+
+  defp parse_headers(headers) do
+    headers
+    |> Map.new
   end
 end

--- a/test/lib/api_test.exs
+++ b/test/lib/api_test.exs
@@ -128,4 +128,36 @@ defmodule Darkskyx.ApiTest do
       end
     end
   end
+
+  describe "forecast_with_headers/3" do
+    test "no options", %{forecast_keys: forecast_keys} do
+      use_cassette "valid_forecast" do
+        {:ok, forecast, headers} = Api.forecast_with_headers(39.749476, -104.991428)
+
+        forecast_keys
+        |> Enum.each(fn key ->
+          assert Enum.member?(Map.keys(forecast), key)
+        end)
+
+        assert "max-age=60" == headers["Cache-Control"]
+        assert "1" == headers["X-Forecast-API-Calls"]
+      end
+    end
+  end
+
+  describe "time_machine_with_headers/3" do
+    test "no options", %{time_machine_keys: time_machine_keys} do
+      use_cassette "valid_time_machine" do
+        {:ok, time_machine, headers} = Api.time_machine_with_headers(39.749476, -104.991428, @time)
+
+        time_machine_keys
+        |> Enum.each(fn key ->
+          assert Enum.member?(Map.keys(time_machine), key)
+        end)
+
+        assert "max-age=3600" == headers["Cache-Control"]
+        assert "5" == headers["X-Forecast-API-Calls"]
+      end
+    end
+  end
 end


### PR DESCRIPTION
A possible way to allow consumers of this library to handle cache-control or rate-limiting in their applications. 